### PR TITLE
Add 2026-08-10 changelog entries (Q2: models, deprecations, rate limits, SDKs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,56 @@
 # Groq Changelog
 
 
+## 2026-08-10 (Python SDK v1.6.0, TypeScript SDK v1.5.0)
+
+### [ADDED] MiniMax M2.7 (Enterprise)
+
+[`minimaxai/minimax-m2.7`](https://console.groq.com/docs/model/minimaxai/minimax-m2.7) is now available on GroqCloud for Enterprise customers. MiniMax M2.7 is a 229-billion-parameter Mixture-of-Experts model (~10B active per token) with interleaved thinking, built for agentic workflows, tool use, and coding, with a 196K-token context window on Groq. [Contact sales](https://groq.com/enterprise-access) for access.
+
+
+### [ADDED] Qwen 3.6 27B
+
+[`qwen/qwen3.6-27b`](https://console.groq.com/docs/model/qwen/qwen3.6-27b) is now available on GroqCloud. Qwen 3.6 27B is a 27-billion-parameter multimodal (vision + text) model with flagship-level agentic coding and reasoning. It supports switching between thinking mode (for complex reasoning, math, and coding) and non-thinking mode (for efficient, general-purpose dialogue) within a single model, with a 131K-token context window on Groq.
+
+
+### [ADDED] Input and Output Token Rate Limits (ITPM / OTPM)
+
+In addition to the combined TPM limit, organizations can now be subject to separate per-minute limits on input tokens (ITPM) and output tokens (OTPM). If these limits are configured on your account, your TPM value on the [Limits page](https://console.groq.com/settings/limits) shows an **"X in / Y out"** breakdown on hover. See the [rate limits docs](https://console.groq.com/docs/rate-limits) for details.
+
+
+### [DEPRECATED] Llama 3.1 8B Instant and Llama 3.3 70B Versatile
+
+On June 17, 2026, we announced the deprecation of `llama-3.1-8b-instant` and `llama-3.3-70b-versatile`, with a shutdown date of **August 16, 2026**. We recommend migrating to [`openai/gpt-oss-20b`](https://console.groq.com/docs/model/openai/gpt-oss-20b) (for Llama 3.1 8B Instant) and [`openai/gpt-oss-120b`](https://console.groq.com/docs/model/openai/gpt-oss-120b) or [`qwen/qwen3.6-27b`](https://console.groq.com/docs/model/qwen/qwen3.6-27b) (for Llama 3.3 70B Versatile) before the shutdown date. This deprecation applies to free and developer-tier usage; enterprise customers with a committed-spend contract are not affected. See the [deprecations page](https://console.groq.com/docs/deprecations) for details.
+
+
+### [REMOVED] Qwen 3 32B and Llama 4 Scout 17B
+
+`qwen/qwen3-32b` and `meta-llama/llama-4-scout-17b-16e-instruct` were shut down on July 17, 2026, following the June 17, 2026 deprecation announcement. Recommended replacements are [`openai/gpt-oss-120b`](https://console.groq.com/docs/model/openai/gpt-oss-120b) (for Qwen 3 32B) and [`openai/gpt-oss-120b`](https://console.groq.com/docs/model/openai/gpt-oss-120b) or [`qwen/qwen3.6-27b`](https://console.groq.com/docs/model/qwen/qwen3.6-27b) (for Llama 4 Scout 17B). This applies to free and developer-tier usage; enterprise customers with a committed-spend contract are not affected. See the [deprecations page](https://console.groq.com/docs/deprecations) for details.
+
+
+### [REMOVED] Compound browser_automation Tool
+
+The built-in `browser_automation` tool for [Compound](https://console.groq.com/docs/compound) systems has been retired. Requests that include `browser_automation` in `compound_custom.tools.enabled_tools` are accepted but have no effect. Use `web_search` and `visit_website` for web research, or the [Anchor Browser integration](https://console.groq.com/docs/anchorbrowser) to automate full browser sessions.
+
+
+### [CHANGED] Python SDK v1.6.0 and TypeScript SDK v1.5.0
+
+Both SDKs received a series of updates over Q2.
+
+**Python SDK** ([v1.6.0](https://github.com/groq/groq-python/releases/tag/v1.6.0))
+- **v1.3.0** — Support for setting headers via environment variables; fixed field name format for multipart file arrays.
+- **v1.4.0** — Support for eagerly validating pydantic iterators.
+- **v1.5.0** — API spec updates.
+- **v1.6.0** — CI and workflow template updates.
+
+**TypeScript SDK** ([v1.5.0](https://github.com/groq/groq-typescript/releases/tag/v1.5.0))
+- **v1.2.0** — Support for setting headers via environment variables.
+- **v1.2.1** — Upgraded `tsc-multi` for Node 26 compatibility.
+- **v1.3.0** — API spec updates; send content-type header for requests with an omitted optional body.
+- **v1.4.0 / v1.4.1** — CI workflows run on Node 24; dependency updates.
+- **v1.5.0** — API spec updates.
+
+
 ## 2026-04-18 (Python SDK v1.2.0, TypeScript SDK v1.1.2)
 
 ### [ADDED] MiniMax M2.5 and Qwen3-VL 32B Instruct (Enterprise)


### PR DESCRIPTION
Adds the overdue changelog section covering 2026-04-18 through 2026-08-10, rendered at https://console.groq.com/docs/changelog.

Linear: https://linear.app/groq/issue/GC1-313/update-groqcloud-changelog-consolegroqcomdocschangelog-by-end-of-july

Every entry is traceable to a merged PR, a release, or a live docs page:

| Entry | Evidence |
|---|---|
| [ADDED] MiniMax M2.7 (Enterprise) | groq-console#4270 (merged 2026-07-16); docs page `/docs/model/minimaxai/minimax-m2.7` |
| [ADDED] Qwen 3.6 27B | groq-console#4244 (merged 2026-06-16); docs page `/docs/model/qwen/qwen3.6-27b` |
| [ADDED] ITPM / OTPM rate limits | groq-console#4224 (docs, 2026-05-11) + #4217 (console UI, 2026-05-06); section "Input and Output Token Rate Limits" on `/docs/rate-limits` |
| [DEPRECATED] llama-3.1-8b-instant, llama-3.3-70b-versatile (shutdown 08/16/26) | groq-console#4254 (merged 2026-06-18); "Deprecation History" on `/docs/deprecations` (announced by email 06/17/26) |
| [REMOVED] qwen/qwen3-32b, meta-llama/llama-4-scout-17b-16e-instruct (shutdown 07/17/26) | groq-console#4254 (shutdown dates on `/docs/deprecations`) + #4275 (docs references removed 2026-07-17) |
| [REMOVED] Compound browser_automation tool | groq-console#4239 (deprecate/hide, 2026-06-06) + #4248 (docs note); retirement notice on `/docs/compound/systems` |
| [CHANGED] SDK updates | groq-python releases v1.3.0-v1.6.0; groq-typescript releases v1.2.0-v1.5.0 (release notes on GitHub) |

Heading SDK versions (Python v1.6.0, TypeScript v1.5.0) are the latest releases as of 2026-08-10.
